### PR TITLE
displays create goal screen in a modal and allows to return back

### DIFF
--- a/goalpost/Base.lproj/Main.storyboard
+++ b/goalpost/Base.lproj/Main.storyboard
@@ -42,7 +42,7 @@
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" image="addGoal" title=""/>
                                         <connections>
-                                            <action selector="addNewGoalWasPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="L0T-8K-ckl"/>
+                                            <action selector="addNewGoalWasPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gNM-sX-wnM"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -56,16 +56,16 @@
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="NLG-mi-Pii">
-                                <rect key="frame" x="78.666666666666671" y="204" width="235.66666666666663" height="63"/>
+                                <rect key="frame" x="0.0" y="204" width="393" height="63"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome to GoalPost" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pFU-ii-qgh">
-                                        <rect key="frame" x="0.0" y="0.0" width="235.66666666666666" height="33"/>
+                                        <rect key="frame" x="78.666666666666671" y="0.0" width="235.66666666666663" height="33"/>
                                         <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="24"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="To begin, create a Goal" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YlS-4F-DgG">
-                                        <rect key="frame" x="33.666666666666657" y="41" width="168.33333333333334" height="22"/>
+                                        <rect key="frame" x="112.33333333333333" y="41" width="168.33333333333337" height="22"/>
                                         <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="16"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -125,7 +125,6 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="70" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="ABP-6I-TF6">
                                                     <rect key="frame" x="327" y="10" width="50" height="50"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="height" constant="50" id="7In-da-Rk4"/>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="RgE-ZG-mQX"/>
                                                         <constraint firstAttribute="width" constant="50" id="gtw-Ee-KZG"/>
                                                     </constraints>
@@ -158,15 +157,14 @@
                         <constraints>
                             <constraint firstItem="N6K-yF-9HN" firstAttribute="top" secondItem="UuC-VY-rnq" secondAttribute="bottom" id="918-pX-7jI"/>
                             <constraint firstItem="NLG-mi-Pii" firstAttribute="top" secondItem="UuC-VY-rnq" secondAttribute="bottom" constant="75" id="9Gx-X9-xqm"/>
-                            <constraint firstItem="N6K-yF-9HN" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="LIW-Mm-tz9"/>
+                            <constraint firstItem="UuC-VY-rnq" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="EZJ-va-yYW"/>
+                            <constraint firstItem="NLG-mi-Pii" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="Gxi-1Z-WOm"/>
                             <constraint firstItem="UuC-VY-rnq" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="M4e-3B-H9q"/>
-                            <constraint firstItem="N6K-yF-9HN" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="TaG-gc-TQk"/>
                             <constraint firstItem="N6K-yF-9HN" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="Zyv-YN-aek"/>
                             <constraint firstItem="UuC-VY-rnq" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="cuK-gt-mbJ"/>
-                            <constraint firstItem="N6K-yF-9HN" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="dyR-sQ-6fU"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="NLG-mi-Pii" secondAttribute="trailing" id="ef8-VJ-bwG"/>
                             <constraint firstItem="N6K-yF-9HN" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="fy2-jS-1CY"/>
                             <constraint firstItem="UuC-VY-rnq" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="lYJ-Ez-adC"/>
-                            <constraint firstItem="N6K-yF-9HN" firstAttribute="top" secondItem="UuC-VY-rnq" secondAttribute="bottom" id="lx0-7h-KqB"/>
                             <constraint firstItem="NLG-mi-Pii" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="oX1-Qt-LvL"/>
                             <constraint firstItem="N6K-yF-9HN" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="qAg-Da-pyo"/>
                         </constraints>
@@ -306,7 +304,6 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="270-g7-UoV" firstAttribute="leading" secondItem="Xda-jg-mSU" secondAttribute="leading" constant="16" id="1Ss-wD-h3c"/>
-                            <constraint firstItem="Xda-jg-mSU" firstAttribute="trailing" secondItem="270-g7-UoV" secondAttribute="trailing" constant="16" id="97X-ju-reg"/>
                             <constraint firstItem="qR6-Mf-CoS" firstAttribute="leading" secondItem="Xda-jg-mSU" secondAttribute="leading" constant="16" id="9Az-rG-PgF"/>
                             <constraint firstItem="qaI-ob-n4a" firstAttribute="leading" secondItem="Xda-jg-mSU" secondAttribute="leading" id="DTv-va-evW"/>
                             <constraint firstItem="dDR-Ox-uwz" firstAttribute="top" secondItem="Xda-jg-mSU" secondAttribute="top" id="EoT-1E-uex"/>
@@ -314,7 +311,6 @@
                             <constraint firstItem="dDR-Ox-uwz" firstAttribute="leading" secondItem="Xda-jg-mSU" secondAttribute="leading" id="S7q-T6-5jk"/>
                             <constraint firstItem="dDR-Ox-uwz" firstAttribute="trailing" secondItem="Xda-jg-mSU" secondAttribute="trailing" id="bM1-SU-y1L"/>
                             <constraint firstItem="270-g7-UoV" firstAttribute="top" secondItem="qR6-Mf-CoS" secondAttribute="bottom" constant="10" id="gvn-ku-aql"/>
-                            <constraint firstItem="Xda-jg-mSU" firstAttribute="trailing" secondItem="qR6-Mf-CoS" secondAttribute="trailing" constant="16" id="oQU-eC-UCq"/>
                             <constraint firstItem="270-g7-UoV" firstAttribute="centerX" secondItem="iSS-0v-OiE" secondAttribute="centerX" id="sdV-Dt-42B"/>
                             <constraint firstItem="Xda-jg-mSU" firstAttribute="bottom" secondItem="qaI-ob-n4a" secondAttribute="bottom" id="vY9-ty-SEg"/>
                             <constraint firstItem="qR6-Mf-CoS" firstAttribute="top" secondItem="dDR-Ox-uwz" secondAttribute="bottom" constant="16" id="wfy-0E-xZY"/>

--- a/goalpost/Base.lproj/Main.storyboard
+++ b/goalpost/Base.lproj/Main.storyboard
@@ -42,7 +42,7 @@
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" image="addGoal" title=""/>
                                         <connections>
-                                            <action selector="addNewGoalWasPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="vVQ-1i-9fZ"/>
+                                            <segue destination="2cF-8l-QVZ" kind="presentation" id="5hg-q7-W5H"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -156,15 +156,19 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="N6K-yF-9HN" firstAttribute="top" secondItem="UuC-VY-rnq" secondAttribute="bottom" id="918-pX-7jI"/>
                             <constraint firstItem="NLG-mi-Pii" firstAttribute="top" secondItem="UuC-VY-rnq" secondAttribute="bottom" constant="75" id="9Gx-X9-xqm"/>
                             <constraint firstItem="N6K-yF-9HN" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="LIW-Mm-tz9"/>
                             <constraint firstItem="UuC-VY-rnq" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="M4e-3B-H9q"/>
                             <constraint firstItem="N6K-yF-9HN" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="TaG-gc-TQk"/>
+                            <constraint firstItem="N6K-yF-9HN" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="Zyv-YN-aek"/>
                             <constraint firstItem="UuC-VY-rnq" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="cuK-gt-mbJ"/>
+                            <constraint firstItem="N6K-yF-9HN" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="dyR-sQ-6fU"/>
                             <constraint firstItem="N6K-yF-9HN" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="fy2-jS-1CY"/>
                             <constraint firstItem="UuC-VY-rnq" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="lYJ-Ez-adC"/>
                             <constraint firstItem="N6K-yF-9HN" firstAttribute="top" secondItem="UuC-VY-rnq" secondAttribute="bottom" id="lx0-7h-KqB"/>
                             <constraint firstItem="NLG-mi-Pii" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="oX1-Qt-LvL"/>
+                            <constraint firstItem="N6K-yF-9HN" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="qAg-Da-pyo"/>
                         </constraints>
                     </view>
                     <connections>
@@ -175,14 +179,171 @@
             </objects>
             <point key="canvasLocation" x="96.946564885496173" y="-27.464788732394368"/>
         </scene>
+        <!--CreateGoalVC-->
+        <scene sceneID="OFV-eW-hG6">
+            <objects>
+                <viewController title="CreateGoalVC" id="2cF-8l-QVZ" customClass="CreateGoalVC" customModule="goalpost" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="iSS-0v-OiE">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dDR-Ox-uwz">
+                                <rect key="frame" x="0.0" y="0.0" width="393" height="70"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="BJQ-MH-AXG">
+                                        <rect key="frame" x="143" y="33.333333333333336" width="107" height="24.666666666666664"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GOAL" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VQv-wo-7Jm">
+                                                <rect key="frame" x="0.0" y="0.0" width="51" height="24.666666666666668"/>
+                                                <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="18"/>
+                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="POST" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hLk-tm-BG8">
+                                                <rect key="frame" x="59" y="0.0" width="48" height="24.666666666666668"/>
+                                                <fontDescription key="fontDescription" name="AvenirNext-Bold" family="Avenir Next" pointSize="18"/>
+                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vaD-ol-06b">
+                                        <rect key="frame" x="15" y="26.333333333333329" width="38" height="39"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" image="back" title=""/>
+                                        <connections>
+                                            <action selector="onBackButtonPressed:" destination="2cF-8l-QVZ" eventType="touchUpInside" id="Fjd-RY-KPF"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemGreenColor"/>
+                                <constraints>
+                                    <constraint firstItem="vaD-ol-06b" firstAttribute="centerY" secondItem="BJQ-MH-AXG" secondAttribute="centerY" id="8eb-f3-g6l"/>
+                                    <constraint firstAttribute="bottom" secondItem="BJQ-MH-AXG" secondAttribute="bottom" constant="12" id="D1A-x1-68T"/>
+                                    <constraint firstItem="vaD-ol-06b" firstAttribute="leading" secondItem="dDR-Ox-uwz" secondAttribute="leading" constant="15" id="E7a-sV-q3a"/>
+                                    <constraint firstAttribute="height" constant="70" id="hb0-88-KBt"/>
+                                    <constraint firstItem="BJQ-MH-AXG" firstAttribute="centerX" secondItem="dDR-Ox-uwz" secondAttribute="centerX" id="iJB-Rc-jbF"/>
+                                    <constraint firstItem="BJQ-MH-AXG" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="vaD-ol-06b" secondAttribute="trailing" constant="8" symbolic="YES" id="mhk-8w-INI"/>
+                                </constraints>
+                            </view>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="What is your goal?" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="qR6-Mf-CoS">
+                                <rect key="frame" x="16" y="86" width="361" height="200"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="200" id="pHn-T4-G14"/>
+                                </constraints>
+                                <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <fontDescription key="fontDescription" name="AvenirNext-Medium" family="Avenir Next" pointSize="18"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="270-g7-UoV">
+                                <rect key="frame" x="16" y="296" width="361" height="90.333333333333314"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SELECT ONE:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xz5-uA-8DV">
+                                        <rect key="frame" x="0.0" y="0.0" width="104.33333333333333" height="20.333333333333332"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Uo8-Bt-H1K">
+                                        <rect key="frame" x="0.0" y="40.333333333333314" width="361" height="50"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="O3v-BE-NzY">
+                                                <rect key="frame" x="0.0" y="0.0" width="170.66666666666666" height="50"/>
+                                                <color key="backgroundColor" systemColor="systemGreenColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="50" id="vs4-GL-b45"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="SHORT TERM">
+                                                    <fontDescription key="titleFontDescription" name="AvenirNext-DemiBold" family="Avenir Next" pointSize="14"/>
+                                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </buttonConfiguration>
+                                                <connections>
+                                                    <action selector="onShortTypePressed:" destination="2cF-8l-QVZ" eventType="touchUpInside" id="hBc-eQ-rIZ"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IRV-TS-apx">
+                                                <rect key="frame" x="190.66666666666663" y="0.0" width="170.33333333333337" height="50"/>
+                                                <color key="backgroundColor" red="0.39607840779999998" green="0.76862752440000004" blue="0.40000003579999999" alpha="0.74631657315969313" colorSpace="custom" customColorSpace="displayP3"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="50" id="45w-uN-Hxy"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="LONG TERM">
+                                                    <fontDescription key="titleFontDescription" name="AvenirNext-DemiBold" family="Avenir Next" pointSize="14"/>
+                                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </buttonConfiguration>
+                                                <connections>
+                                                    <action selector="onLongTypePressed:" destination="2cF-8l-QVZ" eventType="touchUpInside" id="DjS-2q-vDc"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="Uo8-Bt-H1K" secondAttribute="trailing" id="5PX-2c-cy4"/>
+                                    <constraint firstItem="Uo8-Bt-H1K" firstAttribute="leading" secondItem="270-g7-UoV" secondAttribute="leading" id="M3o-Vn-M7S"/>
+                                </constraints>
+                            </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qaI-ob-n4a">
+                                <rect key="frame" x="0.0" y="792" width="393" height="50"/>
+                                <color key="backgroundColor" systemColor="systemYellowColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="7Xf-Er-CFi"/>
+                                </constraints>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="NEXT">
+                                    <fontDescription key="titleFontDescription" name="AvenirNext-Bold" family="Avenir Next" pointSize="20"/>
+                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="onNextPressed:" destination="2cF-8l-QVZ" eventType="touchUpInside" id="bcf-GS-IO5"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="Xda-jg-mSU"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="270-g7-UoV" firstAttribute="leading" secondItem="Xda-jg-mSU" secondAttribute="leading" constant="16" id="1Ss-wD-h3c"/>
+                            <constraint firstItem="Xda-jg-mSU" firstAttribute="trailing" secondItem="270-g7-UoV" secondAttribute="trailing" constant="16" id="97X-ju-reg"/>
+                            <constraint firstItem="qR6-Mf-CoS" firstAttribute="leading" secondItem="Xda-jg-mSU" secondAttribute="leading" constant="16" id="9Az-rG-PgF"/>
+                            <constraint firstItem="qaI-ob-n4a" firstAttribute="leading" secondItem="Xda-jg-mSU" secondAttribute="leading" id="DTv-va-evW"/>
+                            <constraint firstItem="dDR-Ox-uwz" firstAttribute="top" secondItem="Xda-jg-mSU" secondAttribute="top" id="EoT-1E-uex"/>
+                            <constraint firstItem="qR6-Mf-CoS" firstAttribute="centerX" secondItem="iSS-0v-OiE" secondAttribute="centerX" id="Jrn-f3-Tn1"/>
+                            <constraint firstItem="dDR-Ox-uwz" firstAttribute="leading" secondItem="Xda-jg-mSU" secondAttribute="leading" id="S7q-T6-5jk"/>
+                            <constraint firstItem="dDR-Ox-uwz" firstAttribute="trailing" secondItem="Xda-jg-mSU" secondAttribute="trailing" id="bM1-SU-y1L"/>
+                            <constraint firstItem="270-g7-UoV" firstAttribute="top" secondItem="qR6-Mf-CoS" secondAttribute="bottom" constant="10" id="gvn-ku-aql"/>
+                            <constraint firstItem="Xda-jg-mSU" firstAttribute="trailing" secondItem="qR6-Mf-CoS" secondAttribute="trailing" constant="16" id="oQU-eC-UCq"/>
+                            <constraint firstItem="270-g7-UoV" firstAttribute="centerX" secondItem="iSS-0v-OiE" secondAttribute="centerX" id="sdV-Dt-42B"/>
+                            <constraint firstItem="Xda-jg-mSU" firstAttribute="bottom" secondItem="qaI-ob-n4a" secondAttribute="bottom" id="vY9-ty-SEg"/>
+                            <constraint firstItem="qR6-Mf-CoS" firstAttribute="top" secondItem="dDR-Ox-uwz" secondAttribute="bottom" constant="16" id="wfy-0E-xZY"/>
+                            <constraint firstItem="Xda-jg-mSU" firstAttribute="trailing" secondItem="qaI-ob-n4a" secondAttribute="trailing" id="wr0-JI-2kR"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="goalLongType" destination="IRV-TS-apx" id="DmO-LS-VaA"/>
+                        <outlet property="goalShortType" destination="O3v-BE-NzY" id="tBK-ko-DMx"/>
+                        <outlet property="goalTitle" destination="qR6-Mf-CoS" id="FLE-fY-Ka2"/>
+                        <outlet property="nextButton" destination="qaI-ob-n4a" id="N0G-gz-IHr"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="N3K-ZY-wVh" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="841.9847328244274" y="-27.464788732394368"/>
+        </scene>
     </scenes>
     <resources>
         <image name="addGoal" width="35" height="32"/>
+        <image name="back" width="14" height="25"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGreenColor">
             <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemYellowColor">
+            <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/goalpost/Base.lproj/Main.storyboard
+++ b/goalpost/Base.lproj/Main.storyboard
@@ -12,7 +12,7 @@
         <!--GoalsVC-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="GoalsVC" customModule="goalpost" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="GoalsVC" id="BYZ-38-t0r" customClass="GoalsVC" customModule="goalpost" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -42,7 +42,7 @@
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" image="addGoal" title=""/>
                                         <connections>
-                                            <segue destination="2cF-8l-QVZ" kind="presentation" id="5hg-q7-W5H"/>
+                                            <action selector="addNewGoalWasPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="L0T-8K-ckl"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -182,16 +182,16 @@
         <!--CreateGoalVC-->
         <scene sceneID="OFV-eW-hG6">
             <objects>
-                <viewController title="CreateGoalVC" id="2cF-8l-QVZ" customClass="CreateGoalVC" customModule="goalpost" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="CreateGoalVC" title="CreateGoalVC" id="2cF-8l-QVZ" customClass="CreateGoalVC" customModule="goalpost" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="iSS-0v-OiE">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dDR-Ox-uwz">
-                                <rect key="frame" x="0.0" y="0.0" width="393" height="70"/>
+                                <rect key="frame" x="0.0" y="59" width="393" height="70"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="BJQ-MH-AXG">
-                                        <rect key="frame" x="143" y="33.333333333333336" width="107" height="24.666666666666664"/>
+                                        <rect key="frame" x="143" y="33.333333333333329" width="107" height="24.666666666666671"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GOAL" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VQv-wo-7Jm">
                                                 <rect key="frame" x="0.0" y="0.0" width="51" height="24.666666666666668"/>
@@ -227,7 +227,7 @@
                                 </constraints>
                             </view>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="What is your goal?" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="qR6-Mf-CoS">
-                                <rect key="frame" x="16" y="86" width="361" height="200"/>
+                                <rect key="frame" x="16" y="145" width="361" height="200"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="200" id="pHn-T4-G14"/>
@@ -237,7 +237,7 @@
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="270-g7-UoV">
-                                <rect key="frame" x="16" y="296" width="361" height="90.333333333333314"/>
+                                <rect key="frame" x="16" y="355" width="361" height="90.333333333333314"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SELECT ONE:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xz5-uA-8DV">
                                         <rect key="frame" x="0.0" y="0.0" width="104.33333333333333" height="20.333333333333332"/>
@@ -287,7 +287,7 @@
                                 </constraints>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qaI-ob-n4a">
-                                <rect key="frame" x="0.0" y="792" width="393" height="50"/>
+                                <rect key="frame" x="0.0" y="768" width="393" height="50"/>
                                 <color key="backgroundColor" systemColor="systemYellowColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="7Xf-Er-CFi"/>
@@ -340,7 +340,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGreenColor">
-            <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemYellowColor">
             <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/goalpost/Controllers/CreateGoalVC.swift
+++ b/goalpost/Controllers/CreateGoalVC.swift
@@ -22,7 +22,7 @@ class CreateGoalVC: UIViewController {
     
     
     @IBAction func onBackButtonPressed(_ sender: Any) {
-        dismiss(animated: true, completion: nil)
+        dismissDetail(self)
     }
     
     @IBAction func onLongTypePressed(_ sender: Any) {

--- a/goalpost/Controllers/CreateGoalVC.swift
+++ b/goalpost/Controllers/CreateGoalVC.swift
@@ -1,0 +1,47 @@
+//
+//  CreateGoalVC.swift
+//  goalpost
+//
+//  Created by Erick Rocha on 24.12.24.
+//
+
+import UIKit
+
+class CreateGoalVC: UIViewController {
+    
+    @IBOutlet weak var goalLongType: UIButton!
+    @IBOutlet weak var goalShortType: UIButton!
+    @IBOutlet weak var goalTitle: UITextView!
+    @IBOutlet weak var nextButton: UIButton!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+    
+    @IBAction func onBackButtonPressed(_ sender: Any) {
+        dismiss(animated: true, completion: nil)
+    }
+    
+    @IBAction func onLongTypePressed(_ sender: Any) {
+    }
+    
+    @IBAction func onShortTypePressed(_ sender: Any) {
+    }
+    
+    @IBAction func onNextPressed(_ sender: Any) {
+    }
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/goalpost/Controllers/CreateGoalVC.swift
+++ b/goalpost/Controllers/CreateGoalVC.swift
@@ -13,11 +13,15 @@ class CreateGoalVC: UIViewController {
     @IBOutlet weak var goalShortType: UIButton!
     @IBOutlet weak var goalTitle: UITextView!
     @IBOutlet weak var nextButton: UIButton!
+    
+    var goalType: GoalType = .ShortTerm
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
+        nextButton.bindtoKeyboard()
+        goalShortType.setSelectedColor()
+        goalLongType.setDeselectedColor()
     }
     
     
@@ -26,9 +30,15 @@ class CreateGoalVC: UIViewController {
     }
     
     @IBAction func onLongTypePressed(_ sender: Any) {
+        goalType = .LongTerm
+        goalShortType.setDeselectedColor()
+        goalLongType.setSelectedColor()
     }
     
     @IBAction func onShortTypePressed(_ sender: Any) {
+        goalType = .ShortTerm
+        goalShortType.setSelectedColor()
+        goalLongType.setDeselectedColor()
     }
     
     @IBAction func onNextPressed(_ sender: Any) {

--- a/goalpost/Controllers/GoalsVC.swift
+++ b/goalpost/Controllers/GoalsVC.swift
@@ -27,6 +27,8 @@ class GoalsVC: UIViewController {
             return
         }
         
+        createGoalsVC.modalPresentationStyle = .overCurrentContext
+        
         presentDetail(createGoalsVC)
     }
 }

--- a/goalpost/Controllers/GoalsVC.swift
+++ b/goalpost/Controllers/GoalsVC.swift
@@ -10,6 +10,7 @@ import UIKit
 class GoalsVC: UIViewController {
 
     @IBOutlet weak var tableView: UITableView!
+    @IBOutlet weak var createGoal: UIButton!
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/goalpost/Controllers/GoalsVC.swift
+++ b/goalpost/Controllers/GoalsVC.swift
@@ -23,7 +23,11 @@ class GoalsVC: UIViewController {
     }
     
     @IBAction func addNewGoalWasPressed(_ sender: Any) {
-        print("button was pressed")
+        guard let createGoalsVC = storyboard?.instantiateViewController(withIdentifier: "CreateGoalVC") else {
+            return
+        }
+        
+        presentDetail(createGoalsVC)
     }
 }
 

--- a/goalpost/Extensions/UIButtonExt.swift
+++ b/goalpost/Extensions/UIButtonExt.swift
@@ -1,0 +1,18 @@
+//
+//  UIButtonExt.swift
+//  goalpost
+//
+//  Created by Erick Rocha on 25.12.24.
+//
+
+import UIKit
+
+extension UIButton {
+    func setSelectedColor() {
+        self.backgroundColor = .systemGreen
+    }
+    
+    func setDeselectedColor() {
+        self.backgroundColor = .systemGreen.withAlphaComponent(0.5)
+    }
+}

--- a/goalpost/Extensions/UIViewControllerExt.swift
+++ b/goalpost/Extensions/UIViewControllerExt.swift
@@ -1,0 +1,30 @@
+//
+//  UIViewControllerExt.swift
+//  goalpost
+//
+//  Created by Erick Rocha on 25.12.24.
+//
+
+import UIKit
+
+extension UIViewController {
+    func presentDetail(_ viewControllerToPresent: UIViewController) {
+        let transition = CATransition()
+        transition.duration = 0.3
+        transition.type = CATransitionType.push
+        transition.subtype = CATransitionSubtype.fromRight
+        self.view.window?.layer.add(transition, forKey: "kCATransition")
+        
+        present(viewControllerToPresent, animated: false, completion: nil)
+    }
+    
+    func dismissDetail(_ viewControllerToPresent: UIViewController) {
+        let transition = CATransition()
+        transition.duration = 0.3
+        transition.type = CATransitionType.push
+        transition.subtype = CATransitionSubtype.fromLeft
+        self.view.window?.layer.add(transition, forKey: "kCATransition")
+        
+        dismiss(animated: false, completion: nil)
+    }
+}

--- a/goalpost/Extensions/UIViewControllerExt.swift
+++ b/goalpost/Extensions/UIViewControllerExt.swift
@@ -13,7 +13,7 @@ extension UIViewController {
         transition.duration = 0.3
         transition.type = CATransitionType.push
         transition.subtype = CATransitionSubtype.fromRight
-        self.view.window?.layer.add(transition, forKey: "kCATransition")
+        self.view.window?.layer.add(transition, forKey: "CATransition")
         
         present(viewControllerToPresent, animated: false, completion: nil)
     }
@@ -23,7 +23,7 @@ extension UIViewController {
         transition.duration = 0.3
         transition.type = CATransitionType.push
         transition.subtype = CATransitionSubtype.fromLeft
-        self.view.window?.layer.add(transition, forKey: "kCATransition")
+        self.view.window?.layer.add(transition, forKey: "CATransition")
         
         dismiss(animated: false, completion: nil)
     }

--- a/goalpost/Extensions/UIViewExt.swift
+++ b/goalpost/Extensions/UIViewExt.swift
@@ -1,0 +1,27 @@
+//
+//  UIViewExt.swift
+//  goalpost
+//
+//  Created by Erick Rocha on 25.12.24.
+//
+
+import UIKit
+
+extension UIView {
+    func bindtoKeyboard() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillChange(_:)), name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
+    }
+    
+    @objc func keyboardWillChange(_ notification: NSNotification) {
+        let duration = notification.userInfo![UIResponder.keyboardAnimationDurationUserInfoKey] as! Double
+        let curve = notification.userInfo![UIResponder.keyboardAnimationCurveUserInfoKey] as! UInt
+        let startingFrame = (notification.userInfo![UIResponder.keyboardFrameBeginUserInfoKey] as! NSValue).cgRectValue
+        let endingFrame = (notification.userInfo![UIResponder.keyboardFrameEndUserInfoKey] as! NSValue).cgRectValue
+        
+        let deltaY = endingFrame.origin.y - startingFrame.origin.y
+        
+        UIView.animateKeyframes(withDuration: duration, delay: 0.0, options: UIView.KeyframeAnimationOptions.init(rawValue: curve), animations: {
+            self.frame.origin.y += deltaY
+        }, completion: nil)
+    }
+}


### PR DESCRIPTION
this PR adds create goal screen for the project

it adds a few extensions, like for UIButton, UIView, and UIViewController. It also adds programmatic load of this screen via button pressing but not via segue, using custom animation.

As explained before, the course uses old versions of iOS, Swift, and Xcode, and as a result, I'm having to make adjustments. One of those adjustments was on how to make the "Create Goal VC" screen to take the full screen as opposed to animate laterally and still appear as a modal.  This was not covered in the course and took me around 1h of research. 

Of course, being a novice with iOS Swift (versus React Native, for example), it took me longer to find out the answer.