### PR TITLE
Creates Finish Goal Screen

### DIFF
--- a/goalpost/Base.lproj/Main.storyboard
+++ b/goalpost/Base.lproj/Main.storyboard
@@ -422,7 +422,7 @@
                                             <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         </buttonConfiguration>
                                         <connections>
-                                            <action selector="onCreateGoalPressed:" destination="aQ9-jK-8LC" eventType="touchUpInside" id="6x3-2M-Kvx"/>
+                                            <action selector="onCreateGoalPressed:" destination="aQ9-jK-8LC" eventType="touchUpInside" id="1f3-uj-Z4X"/>
                                         </connections>
                                     </button>
                                 </subviews>

--- a/goalpost/Base.lproj/Main.storyboard
+++ b/goalpost/Base.lproj/Main.storyboard
@@ -284,37 +284,49 @@
                                     <constraint firstItem="Uo8-Bt-H1K" firstAttribute="leading" secondItem="270-g7-UoV" secondAttribute="leading" id="M3o-Vn-M7S"/>
                                 </constraints>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qaI-ob-n4a">
-                                <rect key="frame" x="0.0" y="768" width="393" height="50"/>
-                                <color key="backgroundColor" systemColor="systemYellowColor"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="m2J-Sc-9aH">
+                                <rect key="frame" x="0.0" y="465.33333333333326" width="393" height="352.66666666666674"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qaI-ob-n4a">
+                                        <rect key="frame" x="0.0" y="302.66666666666669" width="393" height="50"/>
+                                        <color key="backgroundColor" systemColor="systemYellowColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="50" id="7Xf-Er-CFi"/>
+                                        </constraints>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="NEXT">
+                                            <fontDescription key="titleFontDescription" name="AvenirNext-Bold" family="Avenir Next" pointSize="20"/>
+                                            <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="onNextPressed:" destination="2cF-8l-QVZ" eventType="touchUpInside" id="bcf-GS-IO5"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="50" id="7Xf-Er-CFi"/>
+                                    <constraint firstItem="qaI-ob-n4a" firstAttribute="leading" secondItem="m2J-Sc-9aH" secondAttribute="leading" id="DgY-QQ-D3h"/>
+                                    <constraint firstAttribute="bottom" secondItem="qaI-ob-n4a" secondAttribute="bottom" id="FPj-F1-lnh"/>
+                                    <constraint firstAttribute="trailing" secondItem="qaI-ob-n4a" secondAttribute="trailing" id="bYz-7A-5Jh"/>
                                 </constraints>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="NEXT">
-                                    <fontDescription key="titleFontDescription" name="AvenirNext-Bold" family="Avenir Next" pointSize="20"/>
-                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </buttonConfiguration>
-                                <connections>
-                                    <action selector="onNextPressed:" destination="2cF-8l-QVZ" eventType="touchUpInside" id="bcf-GS-IO5"/>
-                                </connections>
-                            </button>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Xda-jg-mSU"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="270-g7-UoV" firstAttribute="leading" secondItem="Xda-jg-mSU" secondAttribute="leading" constant="16" id="1Ss-wD-h3c"/>
+                            <constraint firstItem="m2J-Sc-9aH" firstAttribute="bottom" secondItem="Xda-jg-mSU" secondAttribute="bottom" id="5nF-PP-JyW"/>
+                            <constraint firstItem="m2J-Sc-9aH" firstAttribute="top" secondItem="270-g7-UoV" secondAttribute="bottom" constant="20" id="6UT-5X-TRp"/>
                             <constraint firstItem="qR6-Mf-CoS" firstAttribute="leading" secondItem="Xda-jg-mSU" secondAttribute="leading" constant="16" id="9Az-rG-PgF"/>
-                            <constraint firstItem="qaI-ob-n4a" firstAttribute="leading" secondItem="Xda-jg-mSU" secondAttribute="leading" id="DTv-va-evW"/>
+                            <constraint firstItem="m2J-Sc-9aH" firstAttribute="trailing" secondItem="Xda-jg-mSU" secondAttribute="trailing" id="Dkr-yy-3zQ"/>
                             <constraint firstItem="dDR-Ox-uwz" firstAttribute="top" secondItem="Xda-jg-mSU" secondAttribute="top" id="EoT-1E-uex"/>
                             <constraint firstItem="qR6-Mf-CoS" firstAttribute="centerX" secondItem="iSS-0v-OiE" secondAttribute="centerX" id="Jrn-f3-Tn1"/>
                             <constraint firstItem="dDR-Ox-uwz" firstAttribute="leading" secondItem="Xda-jg-mSU" secondAttribute="leading" id="S7q-T6-5jk"/>
                             <constraint firstItem="dDR-Ox-uwz" firstAttribute="trailing" secondItem="Xda-jg-mSU" secondAttribute="trailing" id="bM1-SU-y1L"/>
                             <constraint firstItem="270-g7-UoV" firstAttribute="top" secondItem="qR6-Mf-CoS" secondAttribute="bottom" constant="10" id="gvn-ku-aql"/>
+                            <constraint firstItem="m2J-Sc-9aH" firstAttribute="leading" secondItem="Xda-jg-mSU" secondAttribute="leading" id="hcc-GC-htU"/>
                             <constraint firstItem="270-g7-UoV" firstAttribute="centerX" secondItem="iSS-0v-OiE" secondAttribute="centerX" id="sdV-Dt-42B"/>
-                            <constraint firstItem="Xda-jg-mSU" firstAttribute="bottom" secondItem="qaI-ob-n4a" secondAttribute="bottom" id="vY9-ty-SEg"/>
                             <constraint firstItem="qR6-Mf-CoS" firstAttribute="top" secondItem="dDR-Ox-uwz" secondAttribute="bottom" constant="16" id="wfy-0E-xZY"/>
-                            <constraint firstItem="Xda-jg-mSU" firstAttribute="trailing" secondItem="qaI-ob-n4a" secondAttribute="trailing" id="wr0-JI-2kR"/>
                         </constraints>
                     </view>
                     <connections>
@@ -331,7 +343,7 @@
         <!--FinishGoalVC-->
         <scene sceneID="fuZ-m9-WmT">
             <objects>
-                <viewController storyboardIdentifier="FinishGoalVC" title="FinishGoalVC" id="aQ9-jK-8LC" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="FinishGoalVC" title="FinishGoalVC" id="aQ9-jK-8LC" customClass="FinishGoalVC" customModule="goalpost" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="lOq-HA-9TV">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -360,6 +372,9 @@
                                         <rect key="frame" x="15" y="26.333333333333329" width="38" height="39"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" image="back" title=""/>
+                                        <connections>
+                                            <action selector="onBackButtonPressed:" destination="aQ9-jK-8LC" eventType="touchUpInside" id="aiY-sH-RdW"/>
+                                        </connections>
                                     </button>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemGreenColor"/>
@@ -372,19 +387,82 @@
                                     <constraint firstAttribute="height" constant="70" id="lQO-VU-fxf"/>
                                 </constraints>
                             </view>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="nKz-bh-EFk">
+                                <rect key="frame" x="20" y="149" width="353" height="128.66666666666663"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="How many points until complete?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mOp-xJ-vcl">
+                                        <rect key="frame" x="0.0" y="0.0" width="353" height="25"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="25" id="0WX-SO-9CU"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="18"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0" textAlignment="center" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="0ps-nu-Jpf">
+                                        <rect key="frame" x="0.0" y="45.000000000000007" width="353" height="83.666666666666686"/>
+                                        <color key="textColor" systemColor="systemGreenColor"/>
+                                        <fontDescription key="fontDescription" name="AvenirNext-Bold" family="Avenir Next" pointSize="54"/>
+                                        <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                    </textField>
+                                </subviews>
+                            </stackView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1Mp-Ta-DNY">
+                                <rect key="frame" x="0.0" y="277.66666666666669" width="393" height="540.33333333333326"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="V9n-Hf-txJ">
+                                        <rect key="frame" x="0.0" y="490.33333333333326" width="393" height="50"/>
+                                        <color key="backgroundColor" systemColor="systemYellowColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="50" id="oaA-UA-SN9"/>
+                                        </constraints>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="CREATE GOAL">
+                                            <fontDescription key="titleFontDescription" name="AvenirNext-Bold" family="Avenir Next" pointSize="20"/>
+                                            <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="onCreateGoalPressed:" destination="aQ9-jK-8LC" eventType="touchUpInside" id="6x3-2M-Kvx"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="V9n-Hf-txJ" secondAttribute="bottom" id="7jn-9H-4LM"/>
+                                    <constraint firstAttribute="trailing" secondItem="V9n-Hf-txJ" secondAttribute="trailing" id="N0Q-hA-WtT"/>
+                                    <constraint firstItem="V9n-Hf-txJ" firstAttribute="leading" secondItem="1Mp-Ta-DNY" secondAttribute="leading" id="vzN-a8-9Hq"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="ZPp-mS-weS"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="1Mp-Ta-DNY" firstAttribute="leading" secondItem="ZPp-mS-weS" secondAttribute="leading" id="7mc-lm-cwd"/>
                             <constraint firstItem="qst-Z9-K4y" firstAttribute="top" secondItem="ZPp-mS-weS" secondAttribute="top" id="7mf-y1-JRA"/>
+                            <constraint firstItem="1Mp-Ta-DNY" firstAttribute="trailing" secondItem="ZPp-mS-weS" secondAttribute="trailing" id="86F-hX-cLe"/>
+                            <constraint firstItem="1Mp-Ta-DNY" firstAttribute="top" secondItem="nKz-bh-EFk" secondAttribute="bottom" id="FBe-Ra-aWe"/>
+                            <constraint firstItem="nKz-bh-EFk" firstAttribute="centerX" secondItem="lOq-HA-9TV" secondAttribute="centerX" id="Gtn-RA-Q4E"/>
+                            <constraint firstItem="1Mp-Ta-DNY" firstAttribute="leading" secondItem="ZPp-mS-weS" secondAttribute="leading" id="HsJ-Kq-Woq"/>
+                            <constraint firstItem="ZPp-mS-weS" firstAttribute="bottom" secondItem="1Mp-Ta-DNY" secondAttribute="bottom" id="LZU-k2-hVk"/>
+                            <constraint firstItem="1Mp-Ta-DNY" firstAttribute="trailing" secondItem="ZPp-mS-weS" secondAttribute="trailing" id="NyC-tj-Agb"/>
+                            <constraint firstItem="ZPp-mS-weS" firstAttribute="trailing" secondItem="nKz-bh-EFk" secondAttribute="trailing" constant="20" id="RAR-IA-fu7"/>
+                            <constraint firstItem="1Mp-Ta-DNY" firstAttribute="leading" secondItem="ZPp-mS-weS" secondAttribute="leading" id="XVS-VN-sIt"/>
+                            <constraint firstItem="nKz-bh-EFk" firstAttribute="leading" secondItem="ZPp-mS-weS" secondAttribute="leading" constant="20" id="bGa-WM-wIX"/>
+                            <constraint firstItem="nKz-bh-EFk" firstAttribute="top" secondItem="qst-Z9-K4y" secondAttribute="bottom" constant="20" id="c20-0S-3i2"/>
                             <constraint firstItem="qst-Z9-K4y" firstAttribute="leading" secondItem="ZPp-mS-weS" secondAttribute="leading" id="cdC-NE-Pi3"/>
+                            <constraint firstItem="1Mp-Ta-DNY" firstAttribute="trailing" secondItem="ZPp-mS-weS" secondAttribute="trailing" id="rhf-uP-32G"/>
                             <constraint firstItem="qst-Z9-K4y" firstAttribute="trailing" secondItem="ZPp-mS-weS" secondAttribute="trailing" id="vVz-Iq-opz"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="backButton" destination="gnr-1y-obw" id="NeW-T2-wQ5"/>
+                        <outlet property="createGoal" destination="V9n-Hf-txJ" id="2mF-j2-lop"/>
+                        <outlet property="target" destination="0ps-nu-Jpf" id="M5T-Ya-PJ7"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Z7k-iO-hvc" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1639" y="-27"/>
+            <point key="canvasLocation" x="1638.9312977099237" y="-27.464788732394368"/>
         </scene>
     </scenes>
     <resources>

--- a/goalpost/Base.lproj/Main.storyboard
+++ b/goalpost/Base.lproj/Main.storyboard
@@ -328,6 +328,64 @@
             </objects>
             <point key="canvasLocation" x="841.9847328244274" y="-27.464788732394368"/>
         </scene>
+        <!--FinishGoalVC-->
+        <scene sceneID="fuZ-m9-WmT">
+            <objects>
+                <viewController storyboardIdentifier="FinishGoalVC" title="FinishGoalVC" id="aQ9-jK-8LC" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="lOq-HA-9TV">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qst-Z9-K4y">
+                                <rect key="frame" x="0.0" y="59" width="393" height="70"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="TxM-Vz-6OY">
+                                        <rect key="frame" x="143" y="33.333333333333329" width="107" height="24.666666666666671"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GOAL" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="os3-0m-Sjw">
+                                                <rect key="frame" x="0.0" y="0.0" width="51" height="24.666666666666668"/>
+                                                <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="18"/>
+                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="POST" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3bx-9O-ffo">
+                                                <rect key="frame" x="59" y="0.0" width="48" height="24.666666666666668"/>
+                                                <fontDescription key="fontDescription" name="AvenirNext-Bold" family="Avenir Next" pointSize="18"/>
+                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gnr-1y-obw">
+                                        <rect key="frame" x="15" y="26.333333333333329" width="38" height="39"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" image="back" title=""/>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemGreenColor"/>
+                                <constraints>
+                                    <constraint firstItem="gnr-1y-obw" firstAttribute="leading" secondItem="qst-Z9-K4y" secondAttribute="leading" constant="15" id="9fo-cu-gSV"/>
+                                    <constraint firstItem="TxM-Vz-6OY" firstAttribute="centerX" secondItem="qst-Z9-K4y" secondAttribute="centerX" id="BOp-6b-zoJ"/>
+                                    <constraint firstItem="TxM-Vz-6OY" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="gnr-1y-obw" secondAttribute="trailing" constant="8" symbolic="YES" id="ZDU-1W-JlJ"/>
+                                    <constraint firstItem="gnr-1y-obw" firstAttribute="centerY" secondItem="TxM-Vz-6OY" secondAttribute="centerY" id="aWu-Rs-ofw"/>
+                                    <constraint firstAttribute="bottom" secondItem="TxM-Vz-6OY" secondAttribute="bottom" constant="12" id="gA1-7W-zNg"/>
+                                    <constraint firstAttribute="height" constant="70" id="lQO-VU-fxf"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="ZPp-mS-weS"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="qst-Z9-K4y" firstAttribute="top" secondItem="ZPp-mS-weS" secondAttribute="top" id="7mf-y1-JRA"/>
+                            <constraint firstItem="qst-Z9-K4y" firstAttribute="leading" secondItem="ZPp-mS-weS" secondAttribute="leading" id="cdC-NE-Pi3"/>
+                            <constraint firstItem="qst-Z9-K4y" firstAttribute="trailing" secondItem="ZPp-mS-weS" secondAttribute="trailing" id="vVz-Iq-opz"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Z7k-iO-hvc" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1639" y="-27"/>
+        </scene>
     </scenes>
     <resources>
         <image name="addGoal" width="35" height="32"/>

--- a/goalpost/Controllers/CreateGoalVC.swift
+++ b/goalpost/Controllers/CreateGoalVC.swift
@@ -57,10 +57,12 @@ class CreateGoalVC: UIViewController, UITextViewDelegate {
     
     func textViewDidBeginEditing(_ textView: UITextView) {
         textView.text = ""
+        textView.textColor = .black
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
         textView.text = "What is your goal?"
+        textView.textColor = .systemGray
     }
 
     /*

--- a/goalpost/Controllers/CreateGoalVC.swift
+++ b/goalpost/Controllers/CreateGoalVC.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class CreateGoalVC: UIViewController {
+class CreateGoalVC: UIViewController, UITextViewDelegate {
     
     @IBOutlet weak var goalLongType: UIButton!
     @IBOutlet weak var goalShortType: UIButton!
@@ -19,6 +19,7 @@ class CreateGoalVC: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        goalTitle.delegate = self
         nextButton.bindtoKeyboard()
         goalShortType.setSelectedColor()
         goalLongType.setDeselectedColor()
@@ -42,6 +43,20 @@ class CreateGoalVC: UIViewController {
     }
     
     @IBAction func onNextPressed(_ sender: Any) {
+        if goalTitle.text != nil && goalTitle.text != "What is your goal?" && goalTitle.text != "" {
+            guard let finishGoalVC = storyboard?.instantiateViewController(withIdentifier: "FinishGoalVC") as? FinishGoalVC else {
+                return
+            }
+            
+            finishGoalVC.initData(description: goalTitle.text, type: goalType)
+            finishGoalVC.modalPresentationStyle = .overCurrentContext
+            
+            presentDetail(finishGoalVC)
+        }
+    }
+    
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        textView.text = ""
     }
 
     /*

--- a/goalpost/Controllers/CreateGoalVC.swift
+++ b/goalpost/Controllers/CreateGoalVC.swift
@@ -51,7 +51,7 @@ class CreateGoalVC: UIViewController, UITextViewDelegate {
             finishGoalVC.initData(description: goalTitle.text, type: goalType)
             finishGoalVC.modalPresentationStyle = .overCurrentContext
             
-            presentDetail(finishGoalVC)
+            presentingViewController?.presentSecondaryDetails(finishGoalVC)
         }
     }
     

--- a/goalpost/Controllers/CreateGoalVC.swift
+++ b/goalpost/Controllers/CreateGoalVC.swift
@@ -58,6 +58,10 @@ class CreateGoalVC: UIViewController, UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         textView.text = ""
     }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        textView.text = "What is your goal?"
+    }
 
     /*
     // MARK: - Navigation

--- a/goalpost/Controllers/FinishGoalVC.swift
+++ b/goalpost/Controllers/FinishGoalVC.swift
@@ -1,0 +1,36 @@
+//
+//  FinishGoalVC.swift
+//  goalpost
+//
+//  Created by Erick Rocha on 25.12.24.
+//
+
+import UIKit
+
+class FinishGoalVC: UIViewController, UITextFieldDelegate {
+    @IBOutlet weak var createGoal: UIButton!
+    @IBOutlet weak var target: UITextField!
+    @IBOutlet weak var backButton: UIButton!
+    
+    var goalDescription: String!
+    var type: GoalType!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        target.delegate = self
+        createGoal.bindtoKeyboard()
+    }
+    
+    func initData(description: String, type: GoalType) {
+        self.goalDescription = description
+        self.type = type
+    }
+    
+    @IBAction func onBackButtonPressed(_ sender: Any) {
+        dismissDetail(self)
+    }
+    
+    @IBAction func onCreateGoalPressed(_ sender: Any) {
+    }
+}

--- a/goalpost/Controllers/FinishGoalVC.swift
+++ b/goalpost/Controllers/FinishGoalVC.swift
@@ -6,13 +6,14 @@
 //
 
 import UIKit
+import CoreData
 
 class FinishGoalVC: UIViewController, UITextFieldDelegate {
     @IBOutlet weak var createGoal: UIButton!
     @IBOutlet weak var target: UITextField!
     @IBOutlet weak var backButton: UIButton!
     
-    var goalDescription: String!
+    var goalTitle: String!
     var type: GoalType!
     
     override func viewDidLoad() {
@@ -23,7 +24,7 @@ class FinishGoalVC: UIViewController, UITextFieldDelegate {
     }
     
     func initData(description: String, type: GoalType) {
-        self.goalDescription = description
+        self.goalTitle = description
         self.type = type
     }
     
@@ -32,5 +33,29 @@ class FinishGoalVC: UIViewController, UITextFieldDelegate {
     }
     
     @IBAction func onCreateGoalPressed(_ sender: Any) {
+        if !target.text!.isEmpty {
+            self.save { complete in
+                dismiss(animated: true, completion: nil)
+            }
+        }
+    }
+    
+    func save(completion: (_ finished: Bool) -> ()) {
+        let managedContext = appDelegate.persistentContainer.viewContext
+        let goal = Goal(context: managedContext)
+        
+        goal.title = self.goalTitle
+        goal.type = self.type.rawValue
+        goal.target = Int32(target.text!)!
+        goal.progress = Int32(0)
+        
+        do {
+            print("saved data")
+            try managedContext.save()
+            completion(true)
+        } catch {
+            debugPrint("Could not save \(error.localizedDescription)")
+            completion(false)
+        }
     }
 }

--- a/goalpost/Controllers/GoalsVC.swift
+++ b/goalpost/Controllers/GoalsVC.swift
@@ -6,6 +6,9 @@
 //
 
 import UIKit
+import CoreData
+
+let appDelegate = UIApplication.shared.delegate as! AppDelegate
 
 class GoalsVC: UIViewController {
 

--- a/goalpost/Extensions/UIViewControllerExt.swift
+++ b/goalpost/Extensions/UIViewControllerExt.swift
@@ -18,6 +18,20 @@ extension UIViewController {
         present(viewControllerToPresent, animated: false, completion: nil)
     }
     
+    func presentSecondaryDetails(_ viewControllerToPresent: UIViewController) {
+        let transition = CATransition()
+        transition.duration = 0.3
+        transition.type = CATransitionType.push
+        transition.subtype = CATransitionSubtype.fromRight
+        
+        guard let presentedViewController = presentedViewController else { return }
+        presentedViewController.dismiss(animated: false) {
+            self.view.window?.layer.add(transition, forKey: "CATransition")
+            
+            self.present(viewControllerToPresent, animated: false, completion: nil)
+        }
+    }
+    
     func dismissDetail(_ viewControllerToPresent: UIViewController) {
         let transition = CATransition()
         transition.duration = 0.3


### PR DESCRIPTION
this PR brings:

- creation of a screen which allows customer to set the target of a short/long goal
- extensions that allows dismissal of screens to lead directly to app home screen
- saving goal data using core data